### PR TITLE
Update role using community.crypto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vagrant/
+/certs/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Generates self-signed CA, client and server certificates. Runs locally on contro
 Notes:
 - Will not overwrite any files in output cert dir
 - Will not copy the files to the remote servers if the local files are unchanged
-- Will optionally (see `populate_etc_hosts` variable) add to each machine's `/etc/hosts`
+- Will optionally (see `gen_tls_populate_etc_hosts` variable) add to each machine's `/etc/hosts`
   a line for each host in the inventory.
 
 
@@ -56,17 +56,17 @@ the resulting relevant files are `copy`ed to the remote target machine.
       srv2:
         ansible_host: 192.168.123.31
     vars:
-      cert_dir: ./certs
-      generate_ca_cert: true
-      generate_client_cert: true
-      generate_server_cert: true
-      tls_ca_email: me@example.org
-      tls_ca_country: EU
-      tls_ca_state: Italy
-      tls_ca_locality: Rome
-      tls_ca_organization: Example Inc.
-      tls_ca_organizationalunit: SysAdmins
-      populate_etc_hosts: yes
+      gen_tls_cert_dir: ./certs
+      gen_tls_generate_ca_cert: true
+      gen_tls_generate_client_cert: true
+      gen_tls_generate_server_cert: true
+      gen_tls_ca_email: me@example.org
+      gen_tls_ca_country: EU
+      gen_tls_ca_state: Italy
+      gen_tls_ca_locality: Rome
+      gen_tls_ca_organization: Example Inc.
+      gen_tls_ca_organizationalunit: SysAdmins
+      gen_tls_populate_etc_hosts: yes
   ```
 
 If you want to tinker, you can use `vagrant` with the provided `Vagrantfile`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generates self-signed CA, client and server certificates. Runs locally on contro
 
 Notes:
 - Will not overwrite any files in output cert dir
-- Ansible crypto modules do not support signing certs with own CA yet, using `shell` command instead. Should be resolved in Ansible 2.7 using the [ownca provider](https://github.com/ansible/ansible/commit/b61b113fb9e3fcfcb25f4a8aaabad618e3209ce1).
+- Will not copy the files to the remote servers if the local files are unchanged
 
 
 Requirements
@@ -19,68 +19,58 @@ See `defaults/main.yml`
 
 Dependencies
 ------------
-- Refer to [Ansible Crypto modules](http://docs.ansible.com/ansible/latest/modules/list_of_crypto_modules.html)
 
+Install dependencies via
+
+```
+$ ansible-galaxy collection install community.crypto
+```
 
 Example Playbook
 ----------------
-**generate-certs.yaml:**
-```
----
 
-# ansible-playbook generate-certs.yaml -i localhost,
-# ansible-playbook generate-certs.yaml -i inventory.yaml
+The provided example `playbook.yml` targets two hosts (take a look at the
+`Vagrantfile`).
 
-- hosts: all
+All the cryptographic relevant operations are performed on the host machine and
+the resulting relevant files are `copy`ed to the remote target machine.
 
-  gather_facts: false
+  - `playbook.yml`
+  ```yaml
+  ---
+  - name: Run role
+    hosts: all
+    roles:
+      - role: generate-tls-certs
+  ```
 
-  tasks:
-    - include_vars: vars.yaml
+  - `inventory.yml`
+  ```yaml
+  ---
+  all:
+    hosts:
+      srv1:
+        ansible_host: 192.168.123.30
+      srv2:
+        ansible_host: 192.168.123.31
+    vars:
+      cert_dir: ./certs
+      generate_ca_cert: true
+      generate_client_cert: true
+      generate_server_cert: true
+      tls_ca_email: me@example.org
+      tls_ca_country: EU
+      tls_ca_state: Italy
+      tls_ca_locality: Rome
+      tls_ca_organization: Example Inc.
+      tls_ca_organizationalunit: SysAdmins
+  ```
 
-    - name: Generate certs
-      import_role:
-        name: generate-tls-certs
+If you want to tinker, you can use `vagrant` with the provided `Vagrantfile`.
+It assumes `vagrant-libvirt` is installed (along with `libvirt`, of course).
 
-```
-
-**vars.yaml:**
-```
----
-  cert_dir: ./certs
-  generate_ca_cert: true
-  generate_client_cert: true
-  generate_server_cert: true
-
-  # -------
-  # CA CERT
-  # -------
-  tls_ca_cert: my-ca.pem
-  tls_ca_csr: my-ca.csr
-  tls_ca_key: my-ca.key
-  tls_ca_country: CA
-  tls_ca_state: Ontario
-  tls_ca_locality: Toronto
-  tls_ca_organization: My Company Inc.
-  tls_ca_organizationalunit: IT
-  tls_ca_commonname: My Certificate Authority
-
-  # -----------
-  # CLIENT CERT
-  # -----------
-  tls_client_cert: my-client.pem
-  tls_client_key: my-client.key
-  tls_client_csr: my-client.csr
-  tls_client_commonname: My Client
+Run it like this:
 
 ```
-
-
-License
--------
-BSD
-
-
-Author Information
-------------------
-[EasyPath IT Solutions Inc.](https://www.easypath.ca)
+$ vagrant up --provider=libvirt --provision
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Generates self-signed CA, client and server certificates. Runs locally on contro
 Notes:
 - Will not overwrite any files in output cert dir
 - Will not copy the files to the remote servers if the local files are unchanged
+- Will optionally (see `populate_etc_hosts` variable) add to each machine's `/etc/hosts`
+  a line for each host in the inventory.
 
 
 Requirements
@@ -64,6 +66,7 @@ the resulting relevant files are `copy`ed to the remote target machine.
       tls_ca_locality: Rome
       tls_ca_organization: Example Inc.
       tls_ca_organizationalunit: SysAdmins
+      populate_etc_hosts: yes
   ```
 
 If you want to tinker, you can use `vagrant` with the provided `Vagrantfile`.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,35 @@
+# This guide is optimized for Vagrant 1.7 and above.
+# Although versions 1.6.x should behave very similarly, it is recommended
+# to upgrade instead of disabling the requirement below.
+Vagrant.require_version ">= 1.7.0"
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "debian/buster64"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  # Disable the new default behavior introduced in Vagrant 1.7, to
+  # ensure that all Vagrant machines will use the same SSH key pair.
+  # See https://github.com/mitchellh/vagrant/issues/5005
+  config.ssh.insert_key = false
+
+  config.vm.provider :libvirt do |lv|
+    lv.cpus = 1
+    lv.memory = 512
+  end
+
+  config.vm.define "srv1" do |m|
+    m.vm.hostname = "srv1"
+    m.vm.network :private_network, ip: "192.168.123.30", libvirt__dhcp_enabled: false
+  end
+  config.vm.define "srv2" do |m|
+    m.vm.hostname = "srv2"
+    m.vm.network :private_network, ip: "192.168.123.31", libvirt__dhcp_enabled: false
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    #ansible.become = true
+    ansible.verbose = "v"
+    ansible.playbook = "playbook.yml"
+    ansible.inventory_path = "inventory.yml"
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = /root/.ansible/roles/:../

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,11 +8,12 @@ gen_tls_remote_ca_certs_dir: /etc/ssl/certs
 gen_tls_generate_ca_cert: false
 gen_tls_generate_client_cert: false
 gen_tls_generate_server_cert: false
+gen_tls_force_copy: false
 
 # -------
 # CA CERT
 # -------
-gen_tls_ca_cert: ca.pem
+gen_tls_ca_cert: ca.crt
 gen_tls_ca_csr: ca.csr
 gen_tls_ca_key: ca.key
 gen_tls_ca_key_size: 4096

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,52 +1,52 @@
 ---
 # defaults file for generate-tls-certs
-generate_tls_certs: true
+gen_tls_generate_certs: true
 # Do not put trailing slash "/"
-cert_dir: ./certs
-remote_certs_dir: /etc/ssl
-remote_ca_certs_dir: /etc/ssl/certs
-generate_ca_cert: false
-generate_client_cert: false
-generate_server_cert: false
+gen_tls_cert_dir: ./certs
+gen_tls_remote_certs_dir: /etc/ssl
+gen_tls_remote_ca_certs_dir: /etc/ssl/certs
+gen_tls_generate_ca_cert: false
+gen_tls_generate_client_cert: false
+gen_tls_generate_server_cert: false
 
 # -------
 # CA CERT
 # -------
-tls_ca_cert: ca.pem
-tls_ca_csr: ca.csr
-tls_ca_key: ca.key
-tls_ca_key_size: 4096
+gen_tls_ca_cert: ca.pem
+gen_tls_ca_csr: ca.csr
+gen_tls_ca_key: ca.key
+gen_tls_ca_key_size: 4096
 # 10 years
-tls_ca_valid_days: 3650
-# tls_ca_country:
-# tls_ca_state:
-# tls_ca_locality:
-# tls_ca_organization:
-# tls_ca_organizationalunit:
-tls_ca_commonname: Certificate Authority
-#tls_ca_email:
+gen_tls_ca_valid_days: 3650
+# gen_tls_ca_country:
+# gen_tls_ca_state:
+# gen_tls_ca_locality:
+# gen_tls_ca_organization:
+# gen_tls_ca_organizationalunit:
+gen_tls_ca_commonname: Certificate Authority
+#gen_tls_ca_email:
 
 # -----------
 # CLIENT CERT
 # -----------
-tls_client_cert: client.pem
-tls_client_key: client.key
-tls_client_csr: client.csr
-tls_client_key_size: 4096
-tls_client_commonname: Client
+gen_tls_client_cert: client.pem
+gen_tls_client_key: client.key
+gen_tls_client_csr: client.csr
+gen_tls_client_key_size: 4096
+gen_tls_client_commonname: Client
 # 2 years
-tls_client_valid_days: 730
+gen_tls_client_valid_days: 730
 
 # -----------
 # SERVER CERT
 # -----------
 # 2 years
-tls_server_valid_days: 730
-tls_server_key_size: 4096
+gen_tls_server_valid_days: 730
+gen_tls_server_key_size: 4096
 # Enable Subject Alternate Name (SAN)
-tls_server_enable_san: true
+gen_tls_server_enable_san: true
 
 # -------------------
 # POPULATE /etc/hosts
 # -------------------
-populate_etc_hosts: false
+gen_tls_populate_etc_hosts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,4 @@ gen_tls_server_enable_san: true
 # POPULATE /etc/hosts
 # -------------------
 gen_tls_populate_etc_hosts: false
+# gen_tls_tld:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,3 +44,8 @@ tls_server_valid_days: 730
 tls_server_key_size: 4096
 # Enable Subject Alternate Name (SAN)
 tls_server_enable_san: true
+
+# -------------------
+# POPULATE /etc/hosts
+# -------------------
+populate_etc_hosts: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,6 @@ tls_client_key: client.key
 tls_client_csr: client.csr
 tls_client_key_size: 4096
 tls_client_commonname: Client
-tls_client_extfile: extfile-client.cnf
 # 2 years
 tls_client_valid_days: 730
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,8 @@
 generate_tls_certs: true
 # Do not put trailing slash "/"
 cert_dir: ./certs
+remote_certs_dir: /etc/ssl
+remote_ca_certs_dir: /etc/ssl/certs
 generate_ca_cert: false
 generate_client_cert: false
 generate_server_cert: false

--- a/inventory.yml
+++ b/inventory.yml
@@ -6,14 +6,14 @@ all:
     srv2:
       ansible_host: 192.168.123.31
   vars:
-    cert_dir: ./certs
-    generate_ca_cert: true
-    generate_client_cert: true
-    generate_server_cert: true
-    tls_ca_email: me@example.org
-    tls_ca_country: EU
-    tls_ca_state: Italy
-    tls_ca_locality: Rome
-    tls_ca_organization: Example Inc.
-    tls_ca_organizationalunit: SysAdmins
-    populate_etc_hosts: yes
+    gen_tls_cert_dir: ./certs
+    gen_tls_generate_ca_cert: true
+    gen_tls_generate_client_cert: true
+    gen_tls_generate_server_cert: true
+    gen_tls_ca_email: me@example.org
+    gen_tls_ca_country: EU
+    gen_tls_ca_state: Italy
+    gen_tls_ca_locality: Rome
+    gen_tls_ca_organization: Example Inc.
+    gen_tls_ca_organizationalunit: SysAdmins
+    gen_tls_populate_etc_hosts: yes

--- a/inventory.yml
+++ b/inventory.yml
@@ -1,0 +1,18 @@
+---
+all:
+  hosts:
+    srv1:
+      ansible_host: 192.168.123.30
+    srv2:
+      ansible_host: 192.168.123.31
+  vars:
+    cert_dir: ./certs
+    generate_ca_cert: true
+    generate_client_cert: true
+    generate_server_cert: true
+    tls_ca_email: me@example.org
+    tls_ca_country: EU
+    tls_ca_state: Italy
+    tls_ca_locality: Rome
+    tls_ca_organization: Example Inc.
+    tls_ca_organizationalunit: SysAdmins

--- a/inventory.yml
+++ b/inventory.yml
@@ -17,3 +17,4 @@ all:
     gen_tls_ca_organization: Example Inc.
     gen_tls_ca_organizationalunit: SysAdmins
     gen_tls_populate_etc_hosts: yes
+    gen_tls_tld: example

--- a/inventory.yml
+++ b/inventory.yml
@@ -16,3 +16,4 @@ all:
     tls_ca_locality: Rome
     tls_ca_organization: Example Inc.
     tls_ca_organizationalunit: SysAdmins
+    populate_etc_hosts: yes

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Run role
+  hosts: all
+  roles:
+    - role: generate-tls-certs

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - community.crypto

--- a/tasks/generate-ca-cert.yaml
+++ b/tasks/generate-ca-cert.yaml
@@ -56,7 +56,7 @@
 - name: Copy the CA certificate to the remote machine
   copy:
     src: "{{ cert_dir }}/{{ tls_ca_cert }}"
-    dest: /etc/ssl/certs/
+    dest: "{{ remote_ca_certs_dir }}"
     mode: 0644
     owner: root
     group: root

--- a/tasks/generate-ca-cert.yaml
+++ b/tasks/generate-ca-cert.yaml
@@ -2,61 +2,61 @@
 - name: Check if the CA private key exists
   delegate_to: localhost
   ansible.builtin.stat:
-    path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
   register: ca_key
 
 - name: Generate CA private key
   delegate_to: localhost
   community.crypto.openssl_privatekey:
-    path: "{{ cert_dir }}/{{ tls_ca_key }}"
-    size: "{{ tls_ca_key_size }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
+    size: "{{ gen_tls_ca_key_size }}"
   run_once: true
   when: not ca_key.stat.exists
 
 - name: Check if the CA CSR exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ tls_ca_csr }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_csr }}"
   register: ca_csr
 
 - name: Create CSR for CA
   delegate_to: localhost
   community.crypto.openssl_csr:
-    path: "{{ cert_dir }}/{{ tls_ca_csr }}"
-    privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_csr }}"
+    privatekey_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
     basic_constraints:
       - "CA:TRUE"
-    common_name: "{{ tls_ca_commonname|default('') }}"
-    country_name: "{{ tls_ca_country|default('') }}"
-    state_or_province_name: "{{ tls_ca_state|default('') }}"
-    locality_name: "{{ tls_ca_locality|default('') }}"
-    organization_name: "{{ tls_ca_organization|default('') }}"
-    organizational_unit_name: "{{ tls_ca_organizationalunit|default('') }}"
-    email_address: "{{ tls_ca_email }}"
+    common_name: "{{ gen_tls_ca_commonname|default('') }}"
+    country_name: "{{ gen_tls_ca_country|default('') }}"
+    state_or_province_name: "{{ gen_tls_ca_state|default('') }}"
+    locality_name: "{{ gen_tls_ca_locality|default('') }}"
+    organization_name: "{{ gen_tls_ca_organization|default('') }}"
+    organizational_unit_name: "{{ gen_tls_ca_organizationalunit|default('') }}"
+    email_address: "{{ gen_tls_ca_email }}"
     use_common_name_for_san: no
   when: not ca_csr.stat.exists
 
 - name: Check if the CA cert exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ tls_ca_cert }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_cert }}"
   register: ca_cert
 
 - name: Create and sign server cert for CA
   delegate_to: localhost
   community.crypto.x509_certificate:
-    path: "{{ cert_dir }}/{{ tls_ca_cert }}"
-    privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
-    csr_path: "{{ cert_dir }}/{{ tls_ca_csr }}"
-    selfsigned_not_after: "+{{ tls_ca_valid_days }}d"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_cert }}"
+    privatekey_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
+    csr_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_csr }}"
+    selfsigned_not_after: "+{{ gen_tls_ca_valid_days }}d"
     provider: selfsigned
   when: not ca_cert.stat.exists
   register: ca_cert_file
 
 - name: Copy the CA certificate to the remote machine
   copy:
-    src: "{{ cert_dir }}/{{ tls_ca_cert }}"
-    dest: "{{ remote_ca_certs_dir }}"
+    src: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_cert }}"
+    dest: "{{ gen_tls_remote_ca_certs_dir }}"
     mode: 0644
     owner: root
     group: root

--- a/tasks/generate-ca-cert.yaml
+++ b/tasks/generate-ca-cert.yaml
@@ -1,20 +1,65 @@
 ---
-  - name: Generate CA private key
-    local_action:
-      module: openssl_privatekey
-      path: "{{cert_dir}}/{{tls_ca_key}}"
-      size: "{{tls_ca_key_size}}"
-    run_once: true
+- name: Check if the CA private key exists
+  delegate_to: localhost
+  ansible.builtin.stat:
+    path: "{{ cert_dir }}/{{ tls_ca_key }}"
+  register: ca_key
 
-  - name: Generate self-signed cert for CA
-    local_action:
-      module: |
-        shell if [ ! -e {{cert_dir}}/{{tls_ca_cert}} ]
-        then
-        openssl req -x509 -new -days {{tls_ca_valid_days}} -sha256 -nodes -key {{cert_dir}}/{{tls_ca_key}} -out {{cert_dir}}/{{tls_ca_cert}} \
-        -subj "{% if tls_ca_country is defined%}/C={{tls_ca_country}}{% endif %}{% if tls_ca_state is defined%}/ST={{tls_ca_state}}{% endif %}{% if tls_ca_locality is defined %}/L={{tls_ca_locality}}{% endif %}{% if tls_ca_organization is defined %}/O={{tls_ca_organization}}{% endif %}{% if tls_ca_organizationalunit is defined %}/OU={{tls_ca_organizationalunit}}{% endif %}/CN={{tls_ca_commonname}}{% if tls_ca_email is defined %}/emailAddress={{tls_ca_email}}{% endif %}"
-        fi
-    args:
-      executable: /bin/bash
-    ignore_errors: true
-    run_once: true
+- name: Generate CA private key
+  delegate_to: localhost
+  community.crypto.openssl_privatekey:
+    path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    size: "{{ tls_ca_key_size }}"
+  run_once: true
+  when: not ca_key.stat.exists
+
+- name: Check if the CA CSR exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ tls_ca_csr }}"
+  register: ca_csr
+
+- name: Create CSR for CA
+  delegate_to: localhost
+  community.crypto.openssl_csr:
+    path: "{{ cert_dir }}/{{ tls_ca_csr }}"
+    privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    basic_constraints:
+      - "CA:TRUE"
+    common_name: "{{ tls_ca_commonname|default('') }}"
+    country_name: "{{ tls_ca_country|default('') }}"
+    state_or_province_name: "{{ tls_ca_state|default('') }}"
+    locality_name: "{{ tls_ca_locality|default('') }}"
+    organization_name: "{{ tls_ca_organization|default('') }}"
+    organizational_unit_name: "{{ tls_ca_organizationalunit|default('') }}"
+    email_address: "{{ tls_ca_email }}"
+    use_common_name_for_san: no
+  when: not ca_csr.stat.exists
+
+- name: Check if the CA cert exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ tls_ca_cert }}"
+  register: ca_cert
+
+- name: Create and sign server cert for CA
+  delegate_to: localhost
+  community.crypto.x509_certificate:
+    path: "{{ cert_dir }}/{{ tls_ca_cert }}"
+    privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    csr_path: "{{ cert_dir }}/{{ tls_ca_csr }}"
+    selfsigned_not_after: "+{{ tls_ca_valid_days }}d"
+    provider: selfsigned
+  when: not ca_cert.stat.exists
+  register: ca_cert_file
+
+- name: Copy the CA certificate to the remote machine
+  copy:
+    src: "{{ cert_dir }}/{{ tls_ca_cert }}"
+    dest: /etc/ssl/certs/
+    mode: 0644
+    owner: root
+    group: root
+    force: yes
+    backup: yes
+  when: ca_cert_file.changed

--- a/tasks/generate-client-cert.yaml
+++ b/tasks/generate-client-cert.yaml
@@ -32,7 +32,7 @@
   become: yes
   copy:
     src: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_key}}"
-    dest: "{{ gen_tls_remote_certs_dir }}/local/certs/"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/private/"
     mode: 0644
     owner: root
     group: root
@@ -80,7 +80,7 @@
   become: yes
   copy:
     src: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_cert }}"
-    dest: "{{ gen_tls_remote_certs_dir }}/local/private"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/certs/"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-client-cert.yaml
+++ b/tasks/generate-client-cert.yaml
@@ -4,7 +4,7 @@
   file:
     state: directory
     recurse: yes
-    path: "/etc/ssl/{{ item.path }}"
+    path: "{{ remote_certs_dir }}/{{ item.path }}"
     mode: "{{ item.mode }}"
     owner: root
     group: root
@@ -32,7 +32,7 @@
   become: yes
   copy:
     src: "{{ cert_dir }}/{{ tls_client_key}}"
-    dest: /etc/ssl/local/certs/
+    dest: "{{ remote_certs_dir }}/local/certs/"
     mode: 0644
     owner: root
     group: root
@@ -80,7 +80,7 @@
   become: yes
   copy:
     src: "{{ cert_dir }}/{{ tls_client_cert }}"
-    dest: /etc/ssl/local/private
+    dest: "{{ remote_certs_dir }}/local/private"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-client-cert.yaml
+++ b/tasks/generate-client-cert.yaml
@@ -36,7 +36,7 @@
     mode: 0644
     owner: root
     group: root
-  when: client_key_file.changed
+  when: client_key_file.changed or gen_tls_force_copy
 
 - name: Check if the client CSR exists
   delegate_to: localhost
@@ -84,4 +84,4 @@
     mode: 0600
     owner: root
     group: root
-  when: client_cert_file.changed
+  when: client_cert_file.changed or gen_tls_force_copy

--- a/tasks/generate-client-cert.yaml
+++ b/tasks/generate-client-cert.yaml
@@ -4,7 +4,7 @@
   file:
     state: directory
     recurse: yes
-    path: "{{ remote_certs_dir }}/{{ item.path }}"
+    path: "{{ gen_tls_remote_certs_dir }}/{{ item.path }}"
     mode: "{{ item.mode }}"
     owner: root
     group: root
@@ -15,14 +15,14 @@
 - name: Check if the client private key exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ tls_client_key }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_key }}"
   register: client_key
 
 - name: Generate client private key
   delegate_to: localhost
   community.crypto.openssl_privatekey:
-    path: "{{ cert_dir }}/{{ tls_client_key }}"
-    size: "{{ tls_client_key_size}}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_key }}"
+    size: "{{ gen_tls_client_key_size}}"
   when:
     - not client_key.stat.exists
     - generate_client_cert
@@ -31,8 +31,8 @@
 - name: Copy the key on the server
   become: yes
   copy:
-    src: "{{ cert_dir }}/{{ tls_client_key}}"
-    dest: "{{ remote_certs_dir }}/local/certs/"
+    src: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_key}}"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/certs/"
     mode: 0644
     owner: root
     group: root
@@ -41,15 +41,15 @@
 - name: Check if the client CSR exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ tls_client_csr }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_csr }}"
   register: client_csr
 
 - name: Generate CSR and key for client cert
   delegate_to: localhost
   community.crypto.openssl_csr:
-    path: "{{ cert_dir }}/{{ tls_client_csr }}"
-    privatekey_path: "{{ cert_dir }}/{{ tls_client_key }}"
-    common_name: "{{ tls_client_commonname }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_csr }}"
+    privatekey_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_key }}"
+    common_name: "{{ gen_tls_client_commonname }}"
     extended_key_usage:
       - clientAuth
   when:
@@ -59,17 +59,17 @@
 - name: Check if the client cert exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ tls_client_cert }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_cert }}"
   register: client_crt
 
 - name: Create and sign server cert request by CA
   delegate_to: localhost
   community.crypto.x509_certificate:
-    path: "{{ cert_dir }}/{{ tls_client_cert }}"
-    csr_path: "{{ cert_dir }}/{{ tls_client_csr }}"
-    ownca_not_after: "+{{ tls_client_valid_days }}d"
-    ownca_path: "{{ cert_dir }}/{{ tls_ca_cert }}"
-    ownca_privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_cert }}"
+    csr_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_csr }}"
+    ownca_not_after: "+{{ gen_tls_client_valid_days }}d"
+    ownca_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_cert }}"
+    ownca_privatekey_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
     provider: ownca
   when:
     - not client_crt.stat.exists
@@ -79,8 +79,8 @@
 - name: Copy the certificate to the remote machine
   become: yes
   copy:
-    src: "{{ cert_dir }}/{{ tls_client_cert }}"
-    dest: "{{ remote_certs_dir }}/local/private"
+    src: "{{ gen_tls_cert_dir }}/{{ gen_tls_client_cert }}"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/private"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-client-cert.yaml
+++ b/tasks/generate-client-cert.yaml
@@ -1,46 +1,87 @@
 ---
+- name: Ensure the custom directories to host certificates are present
+  become: yes
+  file:
+    state: directory
+    recurse: yes
+    path: "/etc/ssl/{{ item.path }}"
+    mode: "{{ item.mode }}"
+    owner: root
+    group: root
+  loop:
+    - {path: local/certs, mode: "0755"}
+    - {path: local/private, mode: "0700"}
 
-  - name: Generate client private key
-    local_action:
-      module: openssl_privatekey
-      path: "{{cert_dir}}/{{tls_client_key}}"
-      size: "{{tls_client_key_size}}"
-    run_once: true
-    when: generate_client_cert
+- name: Check if the client private key exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ tls_client_key }}"
+  register: client_key
 
-  - name: Generate CSR and key for client cert
-    local_action:
-      module: |
-        shell if [ ! -e {{cert_dir}}/{{tls_client_csr}} ]
-        then
-        openssl req -newkey rsa:{{tls_client_key_size}} -nodes -subj "/CN={{tls_client_commonname}}" \
-        -keyout "{{cert_dir}}/{{tls_client_key}}" -out "{{cert_dir}}/{{tls_client_csr}}"
-        fi
-    args:
-      executable: /bin/bash
-    ignore_errors: true
-    run_once: true
-    when: generate_client_cert
+- name: Generate client private key
+  delegate_to: localhost
+  community.crypto.openssl_privatekey:
+    path: "{{ cert_dir }}/{{ tls_client_key }}"
+    size: "{{ tls_client_key_size}}"
+  when:
+    - not client_key.stat.exists
+    - generate_client_cert
+  register: client_key_file
 
-  - name: Add required extension for client authentication
-    local_action:
-      module: >
-        shell echo extendedKeyUsage = clientAuth >> {{cert_dir}}/{{tls_client_extfile}}
-    ignore_errors: true
-    run_once: true
-    when: generate_client_cert
+- name: Copy the key on the server
+  become: yes
+  copy:
+    src: "{{ cert_dir }}/{{ tls_client_key}}"
+    dest: /etc/ssl/local/certs/
+    mode: 0644
+    owner: root
+    group: root
+  when: client_key_file.changed
 
-  # @AB TODO: using OpenSSL CA serial file does not always generate unique serial when running playbook against multiple hosts
-  - name: Sign client cert request with CA
-    local_action:
-      module: |
-        shell if [ ! -e {{cert_dir}}/{{tls_client_cert}} ]
-        then
-        openssl x509 -req -sha256 -days {{tls_client_valid_days}} -CA {{cert_dir}}/{{tls_ca_cert}} -CAkey {{cert_dir}}/{{tls_ca_key}} \
-        -set_serial {{ 999999999 | random }} -in {{cert_dir}}/{{tls_client_csr}} -out {{cert_dir}}/{{tls_client_cert}} -extfile {{cert_dir}}/{{tls_client_extfile}}
-        fi
-    args:
-      executable: /bin/bash
-    ignore_errors: true
-    run_once: true
-    when: generate_client_cert
+- name: Check if the client CSR exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ tls_client_csr }}"
+  register: client_csr
+
+- name: Generate CSR and key for client cert
+  delegate_to: localhost
+  community.crypto.openssl_csr:
+    path: "{{ cert_dir }}/{{ tls_client_csr }}"
+    privatekey_path: "{{ cert_dir }}/{{ tls_client_key }}"
+    common_name: "{{ tls_client_commonname }}"
+    extended_key_usage:
+      - clientAuth
+  when:
+    - not client_csr.stat.exists
+    - generate_client_cert
+
+- name: Check if the client cert exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ tls_client_cert }}"
+  register: client_crt
+
+- name: Create and sign server cert request by CA
+  delegate_to: localhost
+  community.crypto.x509_certificate:
+    path: "{{ cert_dir }}/{{ tls_client_cert }}"
+    csr_path: "{{ cert_dir }}/{{ tls_client_csr }}"
+    ownca_not_after: "+{{ tls_client_valid_days }}d"
+    ownca_path: "{{ cert_dir }}/{{ tls_ca_cert }}"
+    ownca_privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    provider: ownca
+  when:
+    - not client_crt.stat.exists
+    - generate_client_cert
+  register: client_cert_file
+
+- name: Copy the certificate to the remote machine
+  become: yes
+  copy:
+    src: "{{ cert_dir }}/{{ tls_client_cert }}"
+    dest: /etc/ssl/local/private
+    mode: 0600
+    owner: root
+    group: root
+  when: client_cert_file.changed

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -4,7 +4,7 @@
   file:
     state: directory
     recurse: yes
-    path: "{{ remote_certs_dir }}/{{ item.path }}"
+    path: "{{ gen_tls_remote_certs_dir }}/{{ item.path }}"
     mode: "{{ item.mode }}"
     owner: root
     group: root
@@ -15,21 +15,21 @@
 - name: Check if the server private key exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
   register: server_key
 
 - name: Create PEM private key for server
   delegate_to: localhost
   community.crypto.openssl_privatekey:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
   when: not server_key.stat.exists
   register: server_key_file
 
 - name: Copy the key on the server
   become: yes
   copy:
-    src: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
-    dest: "{{ remote_certs_dir }}/local/certs/"
+    src: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/certs/"
     mode: 0644
     owner: root
     group: root
@@ -38,58 +38,58 @@
 - name: Check if the server CSR exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.csr"
   register: server_csr
 
 - name: Create CSR for server cert
   delegate_to: localhost
   community.crypto.openssl_csr:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
-    privatekey_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.csr"
+    privatekey_path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
     common_name: "{{ inventory_hostname_short }}"
   when:
     - not server_csr.stat.exists
-    - generate_server_cert
-    - not tls_server_enable_san
+    - gen_tls_generate_server_cert
+    - not gen_tls_server_enable_san
 
 - name: Create CSR for server cert
   delegate_to: localhost
   community.crypto.openssl_csr:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
-    privatekey_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.csr"
+    privatekey_path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
     common_name: "{{inventory_hostname_short}}"
     subject_alt_name: "DNS:{{inventory_hostname}},DNS:{{inventory_hostname_short}},IP:{{(alt_interface_ip is defined) | ternary(alt_interface_ip, ansible_default_ipv4.address)}},IP:0.0.0.0,IP:127.0.0.1"
   when:
     - not server_csr.stat.exists
-    - generate_server_cert
-    - tls_server_enable_san
+    - gen_tls_generate_server_cert
+    - gen_tls_server_enable_san
 
 - name: Check if the server cert exists
   delegate_to: localhost
   stat:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.pem"
   register: server_crt
 
 - name: Create and sign server cert request by CA
   delegate_to: localhost
   community.crypto.x509_certificate:
-    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
-    csr_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
-    ownca_not_after: "+{{ tls_server_valid_days }}d"
-    ownca_path: "{{ cert_dir }}/{{ tls_ca_cert }}"
-    ownca_privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.pem"
+    csr_path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.csr"
+    ownca_not_after: "+{{ gen_tls_server_valid_days }}d"
+    ownca_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_cert }}"
+    ownca_privatekey_path: "{{ gen_tls_cert_dir }}/{{ gen_tls_ca_key }}"
     provider: ownca
   ignore_errors: true
   when:
     - not server_crt.stat.exists
-    - generate_server_cert
+    - gen_tls_generate_server_cert
   register: server_cert_file
 
 - name: Copy the certificate to the remote machine
   become: yes
   copy:
-    src: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
-    dest: "{{ remote_certs_dir }}/local/private"
+    src: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.pem"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/private"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -1,38 +1,96 @@
 ---
-  # Generate server cert
-  - name: Create CSR for server cert
-    local_action:
-      module: |
-        shell if [ ! -e {{cert_dir}}/{{inventory_hostname_short}}.csr ]
-        then
-        openssl req -newkey rsa:{{tls_server_key_size}} -nodes -subj "/CN={{inventory_hostname}}" \
-        -keyout "{{cert_dir}}/{{inventory_hostname_short}}.key" -out "{{cert_dir}}/{{inventory_hostname_short}}.csr"
-        fi
-    args:
-      executable: /bin/bash
-    ignore_errors: true
-    when: generate_server_cert
+- name: Ensure the custom directories to host certificates are present
+  become: yes
+  file:
+    state: directory
+    recurse: yes
+    path: "/etc/ssl/{{ item.path }}"
+    mode: "{{ item.mode }}"
+    owner: root
+    group: root
+  loop:
+    - {path: local/certs, mode: "0755"}
+    - {path: local/private, mode: "0700"}
 
-  - name: Generate certificate extensions file
-    local_action:
-      module: template
-      src: templates/server-cert-extfile.cnf.j2
-      dest: "{{cert_dir}}/{{inventory_hostname_short}}-extfile.cnf"
-    when:
-      - generate_server_cert
-      - tls_server_enable_san
+- name: Check if the server private key exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+  register: server_key
 
-  - name: Sign server cert request by CA
-    local_action:
-      module: |
-        shell if [ ! -e {{cert_dir}}/{{inventory_hostname_short}}.pem ]
-        then
-        openssl x509 -req -sha256 -days {{tls_server_valid_days}} \
-        -CA "{{cert_dir}}/{{tls_ca_cert}}" -CAkey "{{cert_dir}}/{{tls_ca_key}}" -set_serial {{ 999999999 | random }} \
-        -in "{{cert_dir}}/{{inventory_hostname_short}}.csr" -out "{{cert_dir}}/{{inventory_hostname_short}}.pem" {% if tls_server_enable_san %}-extfile "{{cert_dir}}/{{inventory_hostname_short}}-extfile.cnf"{% endif %}
-        
-        fi
-    args:
-      executable: /bin/bash
-    ignore_errors: true
-    when: generate_server_cert
+- name: Create PEM private key for server
+  delegate_to: localhost
+  community.crypto.openssl_privatekey:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+  when: not server_key.stat.exists
+  register: server_key_file
+
+- name: Copy the key on the server
+  become: yes
+  copy:
+    src: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    dest: /etc/ssl/local/certs/
+    mode: 0644
+    owner: root
+    group: root
+  when: server_key_file.changed
+
+- name: Check if the server CSR exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
+  register: server_csr
+
+- name: Create CSR for server cert
+  delegate_to: localhost
+  community.crypto.openssl_csr:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
+    privatekey_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    common_name: "{{ inventory_hostname_short }}"
+  when:
+    - not server_csr.stat.exists
+    - generate_server_cert
+    - not tls_server_enable_san
+
+- name: Create CSR for server cert
+  delegate_to: localhost
+  community.crypto.openssl_csr:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
+    privatekey_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
+    common_name: "{{inventory_hostname_short}}"
+    subject_alt_name: "DNS:{{inventory_hostname}},DNS:{{inventory_hostname_short}},IP:{{(alt_interface_ip is defined) | ternary(alt_interface_ip, ansible_default_ipv4.address)}},IP:0.0.0.0,IP:127.0.0.1"
+  when:
+    - not server_csr.stat.exists
+    - generate_server_cert
+    - tls_server_enable_san
+
+- name: Check if the server cert exists
+  delegate_to: localhost
+  stat:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
+  register: server_crt
+
+- name: Create and sign server cert request by CA
+  delegate_to: localhost
+  community.crypto.x509_certificate:
+    path: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
+    csr_path: "{{ cert_dir }}/{{ inventory_hostname_short }}.csr"
+    ownca_not_after: "+{{ tls_server_valid_days }}d"
+    ownca_path: "{{ cert_dir }}/{{ tls_ca_cert }}"
+    ownca_privatekey_path: "{{ cert_dir }}/{{ tls_ca_key }}"
+    provider: ownca
+  ignore_errors: true
+  when:
+    - not server_crt.stat.exists
+    - generate_server_cert
+  register: server_cert_file
+
+- name: Copy the certificate to the remote machine
+  become: yes
+  copy:
+    src: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
+    dest: /etc/ssl/local/private
+    mode: 0600
+    owner: root
+    group: root
+  when: server_cert_file.changed

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -4,7 +4,7 @@
   file:
     state: directory
     recurse: yes
-    path: "/etc/ssl/{{ item.path }}"
+    path: "{{ remote_certs_dir }}/{{ item.path }}"
     mode: "{{ item.mode }}"
     owner: root
     group: root
@@ -29,7 +29,7 @@
   become: yes
   copy:
     src: "{{ cert_dir }}/{{ inventory_hostname_short }}.key"
-    dest: /etc/ssl/local/certs/
+    dest: "{{ remote_certs_dir }}/local/certs/"
     mode: 0644
     owner: root
     group: root
@@ -89,7 +89,7 @@
   become: yes
   copy:
     src: "{{ cert_dir }}/{{ inventory_hostname_short }}.pem"
-    dest: /etc/ssl/local/private
+    dest: "{{ remote_certs_dir }}/local/private"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -58,7 +58,7 @@
     path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.csr"
     privatekey_path: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
     common_name: "{{inventory_hostname_short}}"
-    subject_alt_name: "DNS:{{inventory_hostname}},DNS:{{inventory_hostname_short}},IP:{{(alt_interface_ip is defined) | ternary(alt_interface_ip, ansible_default_ipv4.address)}},IP:0.0.0.0,IP:127.0.0.1"
+    subject_alt_name: "{% if gen_tls_tld is defined %}DNS:{{ inventory_hostname_short }}.{{ gen_tls_tld }},{% endif %}DNS:{{inventory_hostname}},DNS:{{inventory_hostname_short}},IP:{{(alt_interface_ip is defined) | ternary(alt_interface_ip, ansible_default_ipv4.address)}},IP:0.0.0.0,IP:127.0.0.1"
   when:
     - not server_csr.stat.exists
     - gen_tls_generate_server_cert

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -29,7 +29,7 @@
   become: yes
   copy:
     src: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.key"
-    dest: "{{ gen_tls_remote_certs_dir }}/local/certs/"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/private/"
     mode: 0644
     owner: root
     group: root
@@ -89,7 +89,7 @@
   become: yes
   copy:
     src: "{{ gen_tls_cert_dir }}/{{ inventory_hostname_short }}.pem"
-    dest: "{{ gen_tls_remote_certs_dir }}/local/private"
+    dest: "{{ gen_tls_remote_certs_dir }}/local/certs"
     mode: 0600
     owner: root
     group: root

--- a/tasks/generate-server-cert.yaml
+++ b/tasks/generate-server-cert.yaml
@@ -33,7 +33,7 @@
     mode: 0644
     owner: root
     group: root
-  when: server_key_file.changed
+  when: server_key_file.changed or gen_tls_force_copy
 
 - name: Check if the server CSR exists
   delegate_to: localhost
@@ -93,4 +93,4 @@
     mode: 0600
     owner: root
     group: root
-  when: server_cert_file.changed
+  when: server_cert_file.changed or gen_tls_force_copy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,3 +21,9 @@
 - name: Populate /etc/hosts with inventory's hosts
   include_tasks: populate-etc-hosts.yaml
   when: gen_tls_populate_etc_hosts|bool
+
+- name: Update system CA on Debian
+  include_tasks: update-debian-ca.yaml
+  when:
+    - gen_tls_generate_certs
+    - ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,19 @@
 ---
 # tasks file for generate-tls-certs
+- name: Generate CA cert
+  include_tasks: generate-ca-cert.yaml
+  when:
+    - generate_tls_certs
+    - generate_ca_cert|bool
 
-  - name: Generate CA cert
-    import_tasks: generate-ca-cert.yaml
-    when: 
-      - generate_tls_certs
-      - generate_ca_cert|bool
+- name: Generate client cert
+  include_tasks: generate-client-cert.yaml
+  when:
+    - generate_tls_certs
+    - generate_client_cert|bool
 
-  - name: Generate client cert
-    import_tasks: generate-client-cert.yaml
-    when: 
-      - generate_tls_certs
-      - generate_client_cert|bool
-
-  - name: Generate server cert
-    import_tasks: generate-server-cert.yaml
-    when: 
-      - generate_tls_certs
-      - generate_server_cert|bool
+- name: Generate server cert
+  include_tasks: generate-server-cert.yaml
+  when:
+    - generate_tls_certs
+    - generate_server_cert|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,21 +3,21 @@
 - name: Generate CA cert
   include_tasks: generate-ca-cert.yaml
   when:
-    - generate_tls_certs
-    - generate_ca_cert|bool
+    - gen_tls_generate_certs
+    - gen_tls_generate_ca_cert|bool
 
 - name: Generate client cert
   include_tasks: generate-client-cert.yaml
   when:
-    - generate_tls_certs
-    - generate_client_cert|bool
+    - gen_tls_generate_certs
+    - gen_tls_generate_client_cert|bool
 
 - name: Generate server cert
   include_tasks: generate-server-cert.yaml
   when:
-    - generate_tls_certs
-    - generate_server_cert|bool
+    - gen_tls_generate_certs
+    - gen_tls_generate_server_cert|bool
 
 - name: Populate /etc/hosts with inventory's hosts
   include_tasks: populate-etc-hosts.yaml
-  when: populate_etc_hosts|bool
+  when: gen_tls_populate_etc_hosts|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,7 @@
   when:
     - generate_tls_certs
     - generate_server_cert|bool
+
+- name: Populate /etc/hosts with inventory's hosts
+  include_tasks: populate-etc-hosts.yaml
+  when: populate_etc_hosts|bool

--- a/tasks/populate-etc-hosts.yaml
+++ b/tasks/populate-etc-hosts.yaml
@@ -4,7 +4,7 @@
   lineinfile:
     dest: /etc/hosts
     regexp: '.*{{ item }}$'
-    line: "{{ hostvars[item].ansible_host }} {{item}}"
+    line: "{{ hostvars[item].ansible_host }} {{item}}{% if gen_tls_tld is defined %} {{ item }}.{{ gen_tls_tld }}{% endif %}"
     state: present
   when: hostvars[item].ansible_host is defined
   loop: "{{ groups.all }}"

--- a/tasks/populate-etc-hosts.yaml
+++ b/tasks/populate-etc-hosts.yaml
@@ -1,0 +1,10 @@
+---
+- name: Add IP address of all hosts to all hosts
+  become: yes
+  lineinfile:
+    dest: /etc/hosts
+    regexp: '.*{{ item }}$'
+    line: "{{ hostvars[item].ansible_host }} {{item}}"
+    state: present
+  when: hostvars[item].ansible_host is defined
+  loop: "{{ groups.all }}"

--- a/tasks/update-debian-ca.yaml
+++ b/tasks/update-debian-ca.yaml
@@ -1,0 +1,8 @@
+---
+- name: Copy the CA certificate to directory for system CA update
+  become: yes
+  shell: "cp {{ gen_tls_remote_ca_certs_dir }}/{{ gen_tls_ca_cert }} /usr/local/share/ca-certificates"
+
+- name: Update the system CA
+  become: yes
+  shell: /usr/sbin/update-ca-certificates

--- a/templates/server-cert-extfile.cnf.j2
+++ b/templates/server-cert-extfile.cnf.j2
@@ -1,3 +1,0 @@
-subjectAltName = DNS:{{inventory_hostname}},DNS:{{inventory_hostname_short}},IP:{{(alt_interface_ip is defined) | ternary(alt_interface_ip, ansible_default_ipv4.address)}},IP:0.0.0.0,IP:127.0.0.1
-
-extendedKeyUsage = serverAuth


### PR DESCRIPTION
Hi! Thank you for this role!
I update it using the ansible `community.crypto` [collection][1]. The logic should be the same and in the original spirit of the role you wrote. I just changed minor things:
 - added an (optional) task to populate the `/etc/hosts` file with the nodes in the inventory
 - added a `Vagrantfile` to test this role locally
 - made so that the certificates are copied to the remote machines in a configurable path that defaults to `/etc/ssl/local/{certs,private}`
 - changed all the variables name to have a _pseudo-namespace_ `gen_tls_`, to ease the use of this role together with others

Let me know what you think of it.


[1]: https://docs.ansible.com/ansible/latest/collections/community/crypto/